### PR TITLE
Fix README encoding and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # bundesSoup
 
 ## Voraussetzungen
-- Python 3.9 (oder höher)
+- Python 3.9 (oder hÃ¶her)
 
-## Ausführen im directory:
+## AusfÃ¼hren im directory:
 python bundesSoup.py
 
-##CSV-Datei wird ins selbe directory gelegt 
+## CSV-Datei wird ins selbe directory gelegt 


### PR DESCRIPTION
## Summary
- convert README to UTF-8
- correct "hher" to "höher" and "Ausfhren" to "Ausführen"
- adjust final heading text

## Testing
- `python -m py_compile bundesSoup.py euParliamentSoup.py hrSoup.py`

------
https://chatgpt.com/codex/tasks/task_e_68488b43017c8324b5f24d2ddefac244