### PR TITLE
Fix hrSoup error handling

### DIFF
--- a/hrSoup.py
+++ b/hrSoup.py
@@ -146,17 +146,17 @@ try:
                 try:
                     # Name: Das <span> mit der Klasse 'marginLeft20'
                     name = row.find_element(By.XPATH, ".//span[contains(@class, 'marginLeft20')]").text.strip()
-                except Exception as e:
+                except Exception:
                     name = ""
                 try:
                     # Sitz: Im <td> mit Klasse 'sitzSuchErgebnisse'
                     sitz = row.find_element(By.XPATH, ".//td[contains(@class, 'sitzSuchErgebnisse')]//span").text.strip()
-                except Exception as e:
+                except Exception:
                     sitz = ""
                 try:
                     # Status: Im <td> mit text-align: center (das Status-Feld)
                     status = row.find_element(By.XPATH, ".//td[contains(@style, 'text-align: center')]//span").text.strip()
-                except Exception as e:
+                except Exception:
                     status = ""
                 
                 # Falls mindestens Name vorhanden ist, speichern


### PR DESCRIPTION
## Summary
- avoid storing unused exception variables in `hrSoup.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68488b428a888324978e10776c8e28c5